### PR TITLE
modify task height

### DIFF
--- a/src/components/Task.css
+++ b/src/components/Task.css
@@ -6,6 +6,7 @@
     margin: 20px 40px;
     background-color: #d9d9d9;
     font-size:auto;
+    height: 80px;
 }
 
 .taskcontents{


### PR DESCRIPTION
## チケットへのリンク
<!--#issue番号でリンク生成-->
#7  の修正

## やったこと
<!--このプルリクで何をしたのか？-->
画面サイズを小さくした時にTaskの表示がぐちゃっとなるのを修正しました

## やらないこと
<!--このプルリクでやらないことは何か？（あれば。無いなら「無し」でOK）（やらない場合は、いつやるのかを明記する。）-->
特になし

## できるようになること（ユーザ目線）
<!--何ができるようになるのか？（あれば。無いなら「無し」でOK）-->
なし

## できなくなること（ユーザ目線）
<!--何ができなくなるのか？（あれば。無いなら「無し」でOK）-->
なし

## 動作確認
<!--どのような動作確認を行ったのか？　結果はどうか？-->
- [x] 画面サイズを小さくしてもレイアウトがそんなに崩れない
<img width="457" alt="image" src="https://github.com/takoko55/myfirst_todo/assets/85686284/4e353e24-fd41-44e6-923a-2850529dd4b9">


## その他
<!--レビュワーへの参考情報（実装上の懸念点や注意点などあれば記載）-->